### PR TITLE
add missing translation filters in template

### DIFF
--- a/src/templates/_components/fields/CalendarizeField_input.twig
+++ b/src/templates/_components/fields/CalendarizeField_input.twig
@@ -55,7 +55,7 @@
                 }}
             </div>
             <div class="calendar-row-item">
-                <span class="label u-bold">to</span>
+                <span class="label u-bold">{{'to'|t("calendarize")}}</span>
             </div>
             <div class="calendar-row-item">
                 {{ 
@@ -139,7 +139,7 @@
         <div class="calendar-row" data-if="{{ namespacedId }}-repeats" data-if-value="1">
             <div class="field">
                 <div class="heading">
-                    <label>Ends Repeat</label>
+                    <label>{{'Ends Repeat'|t("calendarize")}}</label>
                 </div>
 
                 <div class="calendar-row">
@@ -224,7 +224,7 @@
     {% if value is defined and value.startDate %}
         <div class="calendar-data">
             <p>
-                {% if value.hasPassed %}Date:{% else %}Next Occurrence:{% endif %} 
+                {% if value.hasPassed %}{{'Date'|t("calendarize")}}:{% else %}{{'Next Occurrence'|t("calendarize")}}:{% endif %}
                 {% if value.allDay %}
                     <b>{{ value.next.format('m/d/Y') }}</b>
                 {% else %}

--- a/src/translations/en/calendarize.php
+++ b/src/translations/en/calendarize.php
@@ -22,6 +22,7 @@ return [
     'Thu' => 'Thu',
     'Fri' => 'Fri',
     'Sat' => 'Sat',
+    'to' => 'to',
     'Never' => 'Never',
     'On Date' => 'On Date',
     'Daily' => 'Daily',
@@ -33,9 +34,11 @@ return [
     'Repeats' => 'Repeats',
     'Every' => 'Every',
     'Every month on the' => 'Every month on the',
+    'Ends Repeat' => 'Ends Repeat',
     'Date Exceptions' => 'Date Exceptions',
     'Time Exceptions' => 'Time Exceptions',
     'Occurrences' => 'Occurrences',
     'Last Occurrence' => 'Last Occurrence',
-    'Next Occurrence' => 'Next Occurrence'
+    'Next Occurrence' => 'Next Occurrence',
+    'Date' => 'Date'
 ];


### PR DESCRIPTION
Hey there 👋 

Thank you for this plugin! It's well needed 🙂 
I added it today to one of our projects and saw that there are a couple of translation filters missing in the template for the field input. This PR adds those.

Best regards,
Anett