### PR TITLE
fix: date exeptions

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    trailingComma: 'es5',
+    tabWidth: 4,
+    semi: true,
+    singleQuote: true,
+    printWidth: 120,
+};

--- a/src/assetbundles/resources/src/js/modules/exceptions.js
+++ b/src/assetbundles/resources/src/js/modules/exceptions.js
@@ -1,6 +1,4 @@
-import {
-    getDayName
-} from '../util/helpers';
+import { getLocalizeMoment, getLocalizedDayName } from '../util/helpers';
 
 // helper method
 const removeChild = (item, child) => {
@@ -54,10 +52,12 @@ class CalendarException {
             close.setAttribute('data-icon', 'remove');
             close.addEventListener('click', () => {
                 removeChild(this.listing, li);
-            })
+            });
 
             // create base inputs
-            const newValue = this.dateField.value;
+            const localizedMoment = getLocalizeMoment(this.dateField.value);
+            let newValue = localizedMoment.format('D/M/Y');
+
             const name = this.hiddenName;
             const position = name.indexOf('[date]');
             const newFieldName = [name.slice(0, position), `[${length || 0}]`, name.slice(position)].join('');
@@ -65,7 +65,7 @@ class CalendarException {
             const hidden = this.createInput(newFieldName, 'hidden', newValue);
             const timezone = this.createInput(newFieldName.replace('date', 'timezone'), 'hidden', Craft.timezone);
 
-            p.innerHTML = getDayName(newValue) + ', ' + newValue;
+            p.innerHTML = getLocalizedDayName(localizedMoment) + ', ' + localizedMoment.format('L');
 
             li.appendChild(close);
             li.appendChild(hidden);

--- a/src/assetbundles/resources/src/js/util/helpers.js
+++ b/src/assetbundles/resources/src/js/util/helpers.js
@@ -14,6 +14,9 @@ export const getDayName = (date) => {
     return days[d.getDay()];
 };
 
+export const getLocalizedDayName = (mom) => {
+    return mom.format('dddd');
+};
 export const weekOfMonth = (date) => {
     const m = moment(date);
     let w = m.isoWeekday(7).week() - moment(m).startOf('month').isoWeekday(7).week() - 1;

--- a/src/templates/_components/fields/CalendarizeField_input.twig
+++ b/src/templates/_components/fields/CalendarizeField_input.twig
@@ -184,9 +184,10 @@
                     {% if value.exceptions is defined %}
                         {% for key, exception in value.exceptions %}
                             <li>
-                                <div data-icon="remove"></div><p>{{ exception | date('l, m/d/Y') }}</p>
-                                <input type="hidden" name="{{name}}[exceptions][{{key}}][date]" value="{{ exception | date('m/d/Y') }}" />
-                                <input type="hidden" name="{{name}}[exceptions][{{key}}][timezone]" value="{{ craft.app.getTimeZone() }}">
+                                <div data-icon="remove"></div>
+                                <p>{{ exception | date('l, d/m/Y') }}</p>
+                                <input type="hidden" name="{{ name }}[exceptions][{{ key }}][date]" value="{{ exception | date('short') }}"/>
+                                <input type="hidden" name="{{ name }}[exceptions][{{ key }}][timezone]" value="{{ craft.app.getTimeZone() }}"/>
                             </li>
                         {% endfor %}
                     {% endif %}

--- a/src/translations/nb/calendarize.php
+++ b/src/translations/nb/calendarize.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Calendarize plugin for Craft CMS 3.x
+ *
+ * Calendar element types
+ *
+ * @link      https://union.co
+ * @copyright Copyright (c) 2018 Franco Valdes
+ */
+
+/**
+ * @author    Franco Valdes
+ * @package   Calendarize
+ * @since     1.0.0
+ */
+return [
+    'Calendarize plugin loaded' => 'Calendarize plugin lastet',
+    'Sun' => 'Sun',
+    'Mon' => 'Man',
+    'Tue' => 'Tir',
+    'Wed' => 'Ons',
+    'Thu' => 'Tor',
+    'Fri' => 'Fre',
+    'Sat' => 'Lør',
+    'to' => 'til',
+    'Never' => 'Aldri',
+    'On Date' => 'På dato',
+    'Daily' => 'Dag',
+    'Weekly' => 'Uke',
+    'Biweekly (every 2 weeks)' => '2 uker',
+    'Monthly' => 'Måned',
+    'Yearly' => 'år',
+    'All Day' => 'Hele dagen',
+    'Repeats' => 'Repeterer',
+    'Every' => 'Hver',
+    'Every month on the' => 'Hver måned den',
+    'Ends Repeat' => 'Slutter repetering',
+    'Date Exceptions' => 'Dato unntak',
+    'Time Exceptions' => 'Tids unntak',
+    'Occurrences' => 'Hendelser',
+    'Last Occurrence' => 'Siste hendelse',
+    'Next Occurrence' => 'Neste hendelse',
+    'Date' => 'Dato'
+];


### PR DESCRIPTION
**Issue:** There seems to be a problem with date exceptions - the dates are incorrect when the browser is in another language than English. So there's a discrepancy with the formatting of dates.
**Changes**:
We added a new helper:
```
export const getLocalizedDayName = (mom) => {
    return mom.format('dddd');
};
```
This is imported in exceptions.js:
```
import { getLocalizeMoment, getLocalizedDayName } from '../util/helpers';
getLocalizeMoment is also imported here, to define the new value of an exeption: 
const localizedMoment = getLocalizeMoment(this.dateField.value); 
let newValue = localizedMoment.format('D/M/Y');
Instead of just:
const newValue = this.dateField.value;
```

And then it is displayed to the user:
`p.innerHTML = getLocalizedDayName(localizedMoment) + ', ' + localizedMoment.format('L');`

In CalendarizeField_input.twig exception is formatted as 'short':
`<input type="hidden" name="{{ name }}[exceptions][{{ key }}][date]" value="{{ exception | date('short') }}"/>`

Instead of:
`date('m/d/Y')`
